### PR TITLE
Add OCR-based license plate text replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ python -m image_identity.cli \
 
 You can also provide an overlay image for the plate using `--overlay` instead of
 `--text`.
+To automatically recognise the existing plate text and replace it with custom text
+use the `--replace-with` option:
+
+```bash
+python -m image_identity.cli \
+    --input test-data/front.jpg --output processed_images \
+    --replace-with "ANON"
+```
 
 Processed images are written to the specified output directory with license
 plates blurred, replaced by text, or overlaid with a custom image.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 opencv-python
 numpy
+pytesseract
+

--- a/src/image_identity/__init__.py
+++ b/src/image_identity/__init__.py
@@ -1,0 +1,15 @@
+"""Image identity utilities."""
+
+from .cli import process_image
+from .detector import detect_license_plates
+from .ocr import recognize_text
+from .processor import blur_region, overlay_text, overlay_image
+
+__all__ = [
+    "process_image",
+    "detect_license_plates",
+    "recognize_text",
+    "blur_region",
+    "overlay_text",
+    "overlay_image",
+]

--- a/src/image_identity/ocr.py
+++ b/src/image_identity/ocr.py
@@ -1,0 +1,37 @@
+import cv2
+from typing import Tuple
+
+try:
+    import pytesseract
+    _ocr_available = True
+except Exception:  # pragma: no cover - pytesseract may not be installed
+    pytesseract = None
+    _ocr_available = False
+
+
+def recognize_text(image, bbox: Tuple[int, int, int, int]) -> str:
+    """Recognize text within the specified bounding box.
+
+    Parameters
+    ----------
+    image : ndarray
+        Source BGR image.
+    bbox : tuple of int
+        Bounding box ``(x, y, w, h)`` of the region containing text.
+
+    Returns
+    -------
+    str
+        Recognized text or an empty string if OCR is unavailable.
+    """
+    if not _ocr_available:
+        return ""
+
+    x, y, w, h = bbox
+    roi = image[y:y + h, x:x + w]
+    gray = cv2.cvtColor(roi, cv2.COLOR_BGR2GRAY)
+    gray = cv2.bilateralFilter(gray, 11, 17, 17)
+    gray = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)[1]
+    text = pytesseract.image_to_string(gray, config="--psm 7")
+    return text.strip()
+

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,0 +1,44 @@
+import os
+import unittest
+
+try:
+    import cv2
+    from image_identity.ocr import recognize_text
+    from image_identity.detector import detect_license_plates
+    _deps_available = True
+except Exception:
+    cv2 = None
+    recognize_text = None
+    detect_license_plates = None
+    _deps_available = False
+
+
+def _load_sample_image():
+    data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'test-data'))
+    for name in os.listdir(data_dir):
+        if name.endswith('.jpg'):
+            path = os.path.join(data_dir, name)
+            img = cv2.imread(path)
+            if img is not None:
+                return img
+    return None
+
+
+@unittest.skipUnless(_deps_available, "OpenCV and pytesseract are required")
+class TestOCR(unittest.TestCase):
+    def setUp(self):
+        self.image = _load_sample_image()
+        if self.image is None:
+            self.skipTest("No sample image available")
+
+    def test_recognize_text_returns_string(self):
+        plates = detect_license_plates(self.image)
+        if not plates:
+            self.skipTest("No license plates detected")
+        text = recognize_text(self.image, plates[0])
+        self.assertIsInstance(text, str)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add pytesseract as a dependency
- implement license plate text recognition (`recognize_text`) and expose it
- update CLI to support `--replace-with` option using OCR
- document the new feature in README
- add unit test skeleton for OCR logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest discover -v`