### PR TITLE
Fix CLI package path

### DIFF
--- a/image_identity/__init__.py
+++ b/image_identity/__init__.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+# Ensure the package works when running from the repository root without
+# installation by adding the "src" directory to the package search path.
+_src = Path(__file__).resolve().parent.parent / "src" / "image_identity"
+if _src.exists():
+    __path__.append(str(_src))


### PR DESCRIPTION
## Summary
- ensure `python -m image_identity.cli` works from repository root by adding a
  lightweight `image_identity` package

## Testing
- `python -m unittest discover -v`
- `python -m image_identity.cli --input test-data/JAECOO_front.jpg --output processed_images --replace-with "ANON"` *(fails: ModuleNotFoundError: No module named 'cv2')*