### PR TITLE
Support rotated plate overlays

### DIFF
--- a/src/image_identity/processor.py
+++ b/src/image_identity/processor.py
@@ -26,14 +26,51 @@ def overlay_text(image, bbox: Tuple[int, int, int, int], text: str) -> None:
                 font_scale, (0, 0, 0), thickness, cv2.LINE_AA)
 
 
+def _estimate_angle(roi: np.ndarray) -> float:
+    """Return the orientation angle of the prominent contour in ``roi``."""
+    gray = cv2.cvtColor(roi, cv2.COLOR_BGR2GRAY)
+    edges = cv2.Canny(gray, 50, 150)
+    contours, _ = cv2.findContours(edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not contours:
+        return 0.0
+    contour = max(contours, key=cv2.contourArea)
+    rect = cv2.minAreaRect(contour)
+    angle = rect[2]
+    if rect[1][0] < rect[1][1]:
+        angle += 90
+    return angle
+
+
 def overlay_image(image, bbox: Tuple[int, int, int, int], overlay) -> None:
-    """Overlay another image resized to bbox."""
+    """Overlay another image using detected angle while keeping bbox size."""
     x, y, w, h = bbox
+    roi = image[y:y+h, x:x+w]
+    angle = _estimate_angle(roi)
+
     overlay_resized = cv2.resize(overlay, (w, h))
-    if overlay_resized.shape[2] == 4:
-        alpha = overlay_resized[:, :, 3] / 255.0
-        for c in range(3):
-            image[y:y+h, x:x+w, c] = (1 - alpha) * image[y:y+h, x:x+w, c] + \
-                alpha * overlay_resized[:, :, c]
+    src_pts = np.array([[0, 0], [w - 1, 0], [w - 1, h - 1], [0, h - 1]], dtype="float32")
+    dest = src_pts + np.array([x, y], dtype="float32")
+    center = (x + w / 2.0, y + h / 2.0)
+    rot_mtx = cv2.getRotationMatrix2D(center, angle, 1.0)
+    dest_pts = cv2.transform(np.array([dest]), rot_mtx)[0]
+    M = cv2.getPerspectiveTransform(src_pts, dest_pts)
+    warped = cv2.warpPerspective(
+        overlay_resized,
+        M,
+        (image.shape[1], image.shape[0]),
+        borderValue=(0, 0, 0, 0),
+    )
+
+    if warped.shape[2] == 4:
+        mask = warped[:, :, 3]
+        overlay_rgb = warped[:, :, :3]
     else:
-        image[y:y+h, x:x+w] = overlay_resized
+        overlay_rgb = warped
+        mask = cv2.cvtColor(warped, cv2.COLOR_BGR2GRAY)
+        _, mask = cv2.threshold(mask, 0, 255, cv2.THRESH_BINARY)
+
+    mask_inv = cv2.bitwise_not(mask)
+    for c in range(3):
+        bg = cv2.bitwise_and(image[:, :, c], image[:, :, c], mask=mask_inv)
+        fg = cv2.bitwise_and(overlay_rgb[:, :, c], overlay_rgb[:, :, c], mask=mask)
+        image[:, :, c] = cv2.add(bg, fg)

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -7,6 +7,7 @@ try:
     from image_identity import processor
     blur_region = processor.blur_region
     overlay_text = processor.overlay_text
+    overlay_image = processor.overlay_image
     _deps_available = True
 except Exception:  # pragma: no cover - dependencies may be missing
     np = None
@@ -34,6 +35,29 @@ class TestProcessor(unittest.TestCase):
         # Expect some non-zero pixels due to text drawing
         region = img[25:75, 50:150]
         self.assertTrue(np.any(region != 0))
+
+    def test_overlay_image_rotated(self):
+        img = self.image.copy()
+        overlay = np.ones((20, 40, 3), dtype=np.uint8) * 255
+        # draw a rotated rectangle inside bbox to provide orientation cues
+        pts = np.array([[60, 40], [100, 40], [100, 60], [60, 60]], dtype="float32")
+        M = cv2.getRotationMatrix2D((80, 50), 30, 1)
+        rpts = cv2.transform(np.array([pts]), M)[0].astype(int)
+        cv2.fillConvexPoly(img, rpts, (255, 255, 255))
+        overlay_image(img, self.bbox, overlay)
+        self.assertTrue(np.any(img != 0))
+
+    def test_overlay_image_keeps_size(self):
+        img = self.image.copy()
+        overlay = np.ones((20, 40, 3), dtype=np.uint8) * 255
+        overlay_image(img, self.bbox, overlay)
+        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        _, mask = cv2.threshold(gray, 1, 255, cv2.THRESH_BINARY)
+        x, y, w, h = self.bbox
+        bbox_mask = np.zeros_like(mask)
+        cv2.rectangle(bbox_mask, (x, y), (x + w, y + h), 255, -1)
+        outside = cv2.bitwise_and(mask, cv2.bitwise_not(bbox_mask))
+        self.assertLess(np.sum(outside), 0.2 * w * h)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- adjust overlay angle estimation helper
- keep overlay dimensions fixed to bbox
- test that overlay size remains bounded

## Testing
- `python -m unittest discover -v tests`
